### PR TITLE
Implement Recursive AST Extraction for Rust Code with Tree-sitter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,12 +19,7 @@ impl ASTConversionService {
         let tree = parser.parse(&code, None).expect("Failed to parse code");
         ASTConversionService { code, tree }
     }
-    fn gen_json(&self) -> Value {
-        let root_node = self.tree.root_node();
-        let mut j = json!({});
-        for child in root_node.children(&mut root_node.walk()) {}
-        j
-    }
+
     fn generate_json(&self) -> Value {
         let root_node = self.tree.root_node();
         json!({
@@ -41,6 +36,7 @@ impl ASTConversionService {
             "schemas": self.extract_schema(root_node),
         })
     }
+
     fn extract_imports(&self, node: Node) -> Vec<Value> {
         let mut imports = Vec::new();
         for child in node.children(&mut node.walk()) {
@@ -52,6 +48,7 @@ impl ASTConversionService {
         }
         imports
     }
+
     fn extract_functions(&self, node: Node) -> Vec<Value> {
         let mut functions = Vec::new();
         for child in node.children(&mut node.walk()) {
@@ -73,6 +70,7 @@ impl ASTConversionService {
         }
         functions
     }
+
     fn extract_parameters(&self, function_node: Node) -> Vec<Value> {
         let mut parameters = Vec::new();
         if let Some(parameters_node) = function_node.child_by_field_name("parameters") {
@@ -95,6 +93,7 @@ impl ASTConversionService {
         }
         parameters
     }
+
     fn extract_called_methods(&self, function_node: Node) -> Vec<Value> {
         let mut called_methods = Vec::new();
         for descendant in function_node.children(&mut function_node.walk()) {
@@ -109,6 +108,7 @@ impl ASTConversionService {
         }
         called_methods
     }
+
     fn extract_method_variables(&self, function_node: Node) -> Vec<Value> {
         let mut variables = Vec::new();
         for descendant in function_node.children(&mut function_node.walk()) {
@@ -124,6 +124,7 @@ impl ASTConversionService {
         }
         variables
     }
+
     fn extract_structs(&self, node: Node) -> Vec<Value> {
         let mut structs = Vec::new();
         for child in node.children(&mut node.walk()) {
@@ -140,6 +141,7 @@ impl ASTConversionService {
         }
         structs
     }
+
     fn extract_fields(&self, struct_node: Node) -> Vec<Value> {
         let mut fields = Vec::new();
         if let Some(body_node) = struct_node.child_by_field_name("body") {
@@ -156,6 +158,7 @@ impl ASTConversionService {
         }
         fields
     }
+
     fn extract_enums(&self, node: Node) -> Vec<Value> {
         let mut enums = Vec::new();
         for child in node.children(&mut node.walk()) {
@@ -171,6 +174,7 @@ impl ASTConversionService {
         }
         enums
     }
+
     fn extract_variants(&self, enum_node: Node) -> Vec<Value> {
         let mut variants = Vec::new();
         if let Some(body_node) = enum_node.child_by_field_name("body") {
@@ -183,6 +187,7 @@ impl ASTConversionService {
         }
         variants
     }
+
     fn extract_relations(&self, node: Node) -> Vec<Value> {
         let mut relations = Vec::new();
         for child in node.children(&mut node.walk()) {
@@ -218,6 +223,7 @@ impl ASTConversionService {
         }
         relations
     }
+
     fn extract_constants(&self, node: Node) -> Vec<Value> {
         let mut constants = Vec::new();
         for child in node.children(&mut node.walk()) {
@@ -233,6 +239,7 @@ impl ASTConversionService {
         }
         constants
     }
+
     fn extract_modules_and_impls(&self, node: Node) -> Vec<Value> {
         let mut modules = Vec::new();
         for child in node.children(&mut node.walk()) {
@@ -249,6 +256,7 @@ impl ASTConversionService {
         }
         modules
     }
+
     fn extract_metadata(&self, node: Node) -> Vec<Value> {
         let mut metadata = Vec::new();
         for child in node.children(&mut node.walk()) {
@@ -261,12 +269,10 @@ impl ASTConversionService {
         }
         metadata
     }
+
     fn extract_nested(&self, node: Node) -> Vec<Value> {
         let mut nested_items = Vec::new();
         for child in node.children(&mut node.walk()) {
-            println!("===> child.kind() = {}", child.kind());
-            // match child.kind() {
-            // "mod_item" | "impl_item" | "function_item" | "struct_item" | "fn" => {
             if let Some(name_node) = child.child_by_field_name("name") {
                 nested_items.push(json!({
                     "type": child.kind(),
@@ -275,17 +281,12 @@ impl ASTConversionService {
                 }));
             } else {
                 let new_nested_items = self.extract_nested(child);
-                // nested_items.push(json!({
-                //     "type": child.kind(),
-                //     "children": self.extract_nested(child),
-                // }));
+                nested_items.extend(new_nested_items);
             }
-            // }
-            // _ => {}
-            // }
         }
         nested_items
     }
+
     fn extract_globals(&self, node: Node) -> Vec<Value> {
         let mut globals = Vec::new();
         for child in node.children(&mut node.walk()) {
@@ -301,6 +302,7 @@ impl ASTConversionService {
         }
         globals
     }
+
     fn extract_schema(&self, node: Node) -> Vec<Value> {
         let mut schemas = Vec::new();
         for child in node.children(&mut node.walk()) {
@@ -308,7 +310,6 @@ impl ASTConversionService {
                 let struct_name = self.node_text(child.child_by_field_name("name").unwrap());
                 let attributes = self.extract_metadata(child);
                 let fields = self.extract_fields(child);
-                // Extract relationships based on field attributes or annotations
                 let relationships = fields
                     .iter()
                     .filter_map(|field| {
@@ -336,6 +337,7 @@ impl ASTConversionService {
         }
         schemas
     }
+
     fn node_text(&self, node: Node) -> String {
         self.code[node.byte_range()].to_string()
     }
@@ -353,6 +355,5 @@ fn main() {
     let service = ASTConversionService::new(code);
     let json_output = service.generate_json();
 
-    // Pretty-print the JSON output
     println!("{}", serde_json::to_string_pretty(&json_output).unwrap());
 }

--- a/src/try2.rs
+++ b/src/try2.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::cmp;
 use std::str::FromStr;
 use tree_sitter::*;
 
@@ -55,17 +54,28 @@ impl FromStr for Kind {
         match s {
             "source_file" => Ok(Kind::Root),
             "line_comment" => Ok(Kind::Comment),
-            "import" => Ok(Kind::Import),
+            "use_declaration" => Ok(Kind::Import), 
             "struct_item" => Ok(Kind::Struct),
             "enum_item" => Ok(Kind::Enum),
             "attribute_item" => Ok(Kind::Derive),
             "function_item" => Ok(Kind::Function),
             "impl_item" => Ok(Kind::Impl),
-
+            "method_item" => Ok(Kind::Method), 
+            "field_declaration" => Ok(Kind::Field), 
+            "let_declaration" => Ok(Kind::Variable), 
+            "type_item" => Ok(Kind::Type), 
+            "trait_item" => Ok(Kind::Trait), 
+            "if_expression" => Ok(Kind::If), 
+            "else_clause" => Ok(Kind::Else), 
+            "loop_expression" => Ok(Kind::Loop), 
+            "tuple_expression" => Ok(Kind::Tuple), 
+            "array_expression" => Ok(Kind::Array), 
+            "call_expression" => Ok(Kind::FunctionCall), 
             _ => Err(()),
         }
     }
 }
+
 impl Default for Kind {
     fn default() -> Self {
         Kind::Comment
@@ -86,68 +96,48 @@ impl ASTConversionService {
         let tree = parser.parse(&code, None).expect("Failed to parse code");
         ASTConversionService { code, tree }
     }
+
     fn generate_ast_with_relations(&self) -> String {
         let mut ast_root = Thing::new(Kind::Root, "Root".to_string());
-        self.build_ast(0, self.tree.root_node(), &mut ast_root);
+        self.build_ast(self.tree.root_node(), &mut ast_root);
         // Convert AST to JSON
         let json_ast = json!(ast_root);
         serde_json::to_string_pretty(&json_ast).unwrap()
     }
-    fn build_ast(&self, level: u64, node: Node, parent: &mut Thing) {
-        let lvl_prnt = 4;
-        let kind_prnt = Kind::Root;
-        let space = " ".repeat((level * 2) as usize);
-        if level <= lvl_prnt {
-            println!("{} {}: {}", space, level, node.kind());
-            let body = self.node_text(node);
-            // let namey = astring(node.child_by_field_name("name"));
-            println!("          ·{}·", &body[0..cmp::min(18, body.len())]);
-        }
-        if let Some(_) = node.child_by_field_name("name") {
-            //
-        };
+
+    fn build_ast(&self, node: Node, parent: &mut Thing) {
         let node_kind = node.kind().to_string();
-        let is_parents_name = node_kind == "type_identifier";
-        if is_parents_name {
-            parent.name = Some(self.node_text(node).to_string());
-        }
         if let Ok(kind) = Kind::from_str(&node_kind) {
             let mut element = Thing::new(kind, self.node_text(node));
-            // Simplified relation handling (e.g., function to method, struct to field)
-            if node.child_count() > 0 {
-                for child in node.children(&mut node.walk()) {
-                    self.build_ast(level + 1, child, &mut element);
-                    element
-                        .relations
-                        .push(format!("{:?} -> {:?}", parent.kind, element.kind));
-                }
+
+            // Extract name if available
+            if let Some(name_node) = node.child_by_field_name("name") {
+                element.name = Some(self.node_text(name_node));
             }
+
+            // Recursively process child nodes
+            for child in node.children(&mut node.walk()) {
+                self.build_ast(child, &mut element);
+            }
+
+            // Add relations based on parent-child relationships
+            element.relations.push(format!("{:?} -> {:?}", parent.kind, element.kind));
+
             parent.children.push(element);
-        } else {
-            if level == lvl_prnt {
-                // println!("               ...")
-            }
         }
     }
+
     fn node_text(&self, node: Node) -> String {
         self.code[node.byte_range()].to_string()
     }
 }
 
-fn astring(a: Option<String>) -> String {
-    a.unwrap_or("".to_string())
-}
-
-// Example usage (assuming `create_ast_from_code_file` is defined as before)
 fn main() {
-    // let language = "python"; // Example language
-    // let file_path = "path/to/example.py"; // Example file path
-
     let code =
         std::fs::read_to_string("src/try2.rs").expect("Failed to read the Rust source file.");
 
     let service = ASTConversionService::new(code);
 
     let ast_json = service.generate_ast_with_relations();
-    // println!("{}", ast_json);
+    println!("{}", ast_json);
 }


### PR DESCRIPTION
### Problem:
- The existing code does not effectively recurse through the AST to extract all necessary elements like imports, functions, structs, etc.


### Evidence:

https://www.loom.com/share/ae8a24056c084a01b9292cd42dc785ec

      {
      "constants": [],
      "enums": [],
      "functions": [
        {
          "body": "fn main() {\r\n    let args: Vec<String> = env::args().collect();\r\n    if args.len() < 2 {\r\n        eprintln!(\"Usage: {} <rust_source_file>\", args[0]);\r\n        std::process::exit(1);\r\n    }\r\n    let file_path = &args[1];\r\n    let code = fs::read_to_string(file_path).expect(\"Failed to read the Rust source file.\");\r\n\r\n    let service = ASTConversionService::new(code);\r\n    let json_output = service.generate_json();\r\n\r\n    println!(\"{}\", serde_json::to_string_pretty(&json_output).unwrap());\r\n}",
          "called_methods": [],
          "local_variables": [],
          "name": "main",
          "parameters": []
        }
      ],
      "globals": [],
      "imports": [
        {
          "name": "use tree_sitter::{Language, Node, Parser, Tree};"
        },
        {
          "name": "use tree_sitter_rust;"
        },
        {
          "name": "use serde_json::{json, Value};"
        },
        {
          "name": "use std::env;"
        },
        {
          "name": "use std::fs;"
        }
      ],
      "metadata": [],
      "modules_and_impls": [],
      "nested_items": [
        {
          "children": [],
          "name": "env",
          "type": "scoped_identifier"
        },
        {
          "children": [],
          "name": "fs",
          "type": "scoped_identifier"
        },
        {
          "children": [
            {
              "children": [],
              "name": "code",
              "type": "field_declaration"
            },
            {
              "children": [],
              "name": "tree",
              "type": "field_declaration"
            }
          ],
          "name": "ASTConversionService",
          "type": "struct_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            },
            {
              "children": [],
              "name": "LANGUAGE",
              "type": "scoped_identifier"
            },
            {
              "children": [],
              "name": "ASTConversionService",
              "type": "struct_expression"
            }
          ],
          "name": "new",
          "type": "function_item"
        },
        {
          "children": [],
          "name": "generate_json",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_imports",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_functions",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_parameters",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_called_methods",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_method_variables",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_structs",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_fields",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_enums",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_variants",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_relations",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_constants",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_modules_and_impls",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_metadata",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_nested",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_globals",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "extract_schema",
          "type": "function_item"
        },
        {
          "children": [],
          "name": "node_text",
          "type": "function_item"
        },
        {
          "children": [
            {
              "children": [],
              "name": "args",
              "type": "scoped_identifier"
            },
            {
              "children": [
                {
                  "children": [],
                  "name": "process",
                  "type": "scoped_identifier"
                }
              ],
              "name": "exit",
              "type": "scoped_identifier"
            },
            {
              "children": [],
              "name": "read_to_string",
              "type": "scoped_identifier"
            },
            {
              "children": [],
              "name": "new",
              "type": "scoped_identifier"
            }
          ],
          "name": "main",
          "type": "function_item"
        }
      ],
      "relations": [],
      "schemas": [
        {
          "attributes": [],
          "fields": [
            {
              "attributes": [],
              "name": "code",
              "type": "String"
            },
            {
              "attributes": [],
              "name": "tree",
              "type": "Tree"
            }
          ],
          "relationships": [],
          "struct": "ASTConversionService"
        }
      ],
      "structs": [
        {
          "fields": [
            {
              "attributes": [],
              "name": "code",
              "type": "String"
            },
            {
              "attributes": [],
              "name": "tree",
              "type": "Tree"
            }
          ],
          "name": "ASTConversionService"
        }
      ]
    }

### Acceptance Criteria:
- [x] Implement recursive AST traversal using Tree-sitter.
- [x] Extract all relevant elements: imports, functions, structs, enums, relations, constants, modules, metadata, nested items, globals, and schemas.
- [x] Output the extracted data in a structured JSON format.